### PR TITLE
2.0.1: Added new function phpErrors

### DIFF
--- a/files/profile.d/02-php-aliases.sh
+++ b/files/profile.d/02-php-aliases.sh
@@ -23,6 +23,21 @@ function xdebug {
     done;
 }
 
+function phpErrors() {
+    local ini ini_files services state
+    state=$([[ ${1:-1} == 0 ]] && echo "Off" || echo "On");
+    echo $([ ${1:-1} == 0 ] && echo "Disabling" || echo "Enabling")" PHP Error Display:"
+    services=$(ls -a /etc/init.d/ | grep php);
+    ini_files=$(ls -df /opt/phpfarm/inst/php-*/lib/php.ini);
+    for ini in ${ini_files}; do
+        sudo sed -i "s/display_startup_errors = .*/display_startup_errors = ${state}/g" ${ini}
+        sudo sed -i "s/display_errors = .*/display_errors = ${state}/g" ${ini}
+    done;
+    for svc in ${services}; do
+        echo -n "  * Restarting ${svc}... " && sudo service ${svc} restart > null && echo "done."
+    done;
+}
+
 function makePhpShortformAliases {
     local arr config_php i phpa
     source /vagrant/config_php.sh

--- a/files/welcome.txt
+++ b/files/welcome.txt
@@ -31,6 +31,7 @@ The following functions and aliases are available:
 
 \e[1mPHP:\e[0;32m
   phpRestart        - restarts all installed PHP FPM services
+  phpErrors 0|1     - Enables / Disables display_errors and display_startup_errors for all installed PHP versions
   xdebug 0|1        - Enables / Disables xdebug for all installed PHP versions (switching off saves time and memory)
 
   The following PHP versions are available with this release and may be invoked in shell via their aliases:


### PR DESCRIPTION
to enable / disable default displaying of errors for all installed PHP versions.

Michael, I think this is a neat feature.  I added it to my fork and think it could be helpful in a dev environment to have a way by default to easily enable / disable display of errors without folks possibly accidentally committing changes to do this through bootstrap means. 

Offered to Demac with my best wishes - take it or leave it.